### PR TITLE
CR-2 : Muted by default in Mango, with the feasibility to toggle unmute/mute

### DIFF
--- a/mangoSource/src/com/serotonin/mango/vo/User.java
+++ b/mangoSource/src/com/serotonin/mango/vo/User.java
@@ -91,7 +91,7 @@ public class User implements SetPointSource, HttpSessionBindingListener, JsonSer
     private transient Map<String, byte[]> reportImageData;
     private transient PublisherVO<? extends PublishedPointVO> editPublisher;
     private transient ImportTask importTask;
-    private transient boolean muted = false;
+    private transient boolean muted = true;
     private transient DataExportDefinition dataExportDefinition;
     private transient Map<String, Object> attributes = new HashMap<String, Object>();
 


### PR DESCRIPTION
By default, a notification sound plays by default when certain events occur, including when a sensor records a
new value. This feature can be toggled by clicking the mute button on the right side of the navigation bar.

This feature may become useless and annoying if a large amount of sensors are constantly recording
information, so it should be disabled by default. It should not be removed completely, and it should still be
possible to enable and disable the notification sound.

Hence, we have modified the code to have the button muted by default, and also giving the feasibility to the user to toggle between enable/disable according to need.